### PR TITLE
Zerowrite SOCK_SEQPACKET

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,7 +303,7 @@ Can a file descriptor be passed without sending any data?
 And the answer is clearly "no" -- the file descriptor is not passed
 when no data are included in the write.
 
-(update, 2019-5-8 from Yicholas Rishel)
+(update, 2019-5-8 from Nicholas Rishel)
 
 This is true for SOCK_STREAM sockets, but for SOCK_SEQPACKET sockets,
 you *can* do zero-length writes and pass an fd.
@@ -316,7 +316,7 @@ you *can* do zero-length writes and pass an fd.
  2. failing to accept an fd in the receiver results in the fd being
     closed by the kernel.
 
- 3. a file descriptor must be accompanied by some data.
+ 3. a file descriptor must be accompanied by some data if sent via stream.
 
 ## Make X pass file descriptors
 

--- a/zerowrite.c
+++ b/zerowrite.c
@@ -25,17 +25,28 @@ child(int sock)
 	ssize_t	size;
 
 	sleep(1);
-	for (;;) {
-		nfd = 1;
-		size = sock_fd_read(sock, buf, sizeof(buf), &fd, &nfd);
-		if (size <= 0)
-			break;
-		printf ("read %d nfd %d\n", size, nfd);
-		if (nfd == 1) {
-			write(fd, "hello, world\n", 13);
-			close(fd);
-		}
+	size = sock_fd_read(sock, buf, sizeof(buf), NULL, NULL);
+	if (size <= 0) {
+		printf ("<=0");
+		return;
 	}
+	printf ("read %d\n", size);
+
+	nfd = 1;
+	size = sock_fd_read(sock, buf, sizeof(buf), &fd, &nfd);
+	printf ("read %d nfd %d\n", size, nfd);
+	if (nfd == 1) {
+		write(fd, "hello, world\n", 13);
+		close(fd);
+	}
+
+
+	size = sock_fd_read(sock, buf, sizeof(buf), NULL, NULL);
+	if (size <= 0) {
+		printf ("<=0");
+		return;
+	}
+	printf ("read %d\n", size);
 }
 
 void
@@ -60,7 +71,7 @@ main(int argc, char **argv)
 	int	sv[2];
 	int	pid;
 
-	if (socketpair(AF_LOCAL, SOCK_STREAM, 0, sv) < 0) {
+	if (socketpair(AF_LOCAL, SOCK_SEQPACKET, 0, sv) < 0) {
 		perror("socketpair");
 		exit(1);
 	}


### PR DESCRIPTION
Modified the zerowrite example to use SOCK_SEQPACKET to demonstrate zero length file sends.